### PR TITLE
ci: add actions workflow to run unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request: {}
+  push:
+    branches: [ master ]
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout files in the repository
+        uses: actions/checkout@v3
+
+      - name: Run unit tests
+        uses: d3adb5/helm-unittest-action@v1

--- a/tests/__snapshot__/deployment_test.yaml.snap
+++ b/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,6 +7,12 @@ should properly set value:
     - mountPath: /usr/local/tomcat/conf/web.xml
       name: xwiki-tomcat-conf
       subPath: web.xml
+    - mountPath: /usr/local/xwiki/data/xwiki.cfg
+      name: xwiki-cfg
+      subPath: xwiki.cfg
+    - mountPath: /usr/local/xwiki/data/xwiki.properties
+      name: xwiki-properties
+      subPath: xwiki.properties
   2: |
     - name: xwiki-solr-data
       persistentVolumeClaim:
@@ -20,6 +26,18 @@ should properly set value:
           path: web.xml
         name: xwiki-tomcat-conf
       name: xwiki-tomcat-conf
+    - configMap:
+        items:
+        - key: xwiki.cfg
+          path: xwiki.cfg
+        name: xwiki-cfg
+      name: xwiki-cfg
+    - configMap:
+        items:
+        - key: xwiki.properties
+          path: xwiki.properties
+        name: xwiki-properties
+      name: xwiki-properties
 should properly set value for xwiki pvc:
   1: |
     accessModes:

--- a/tests/__snapshot__/gateway_test.yaml.snap
+++ b/tests/__snapshot__/gateway_test.yaml.snap
@@ -24,3 +24,17 @@ should set values properly of Gateway:
         name: http
         number: 80
         protocol: HTTP
+  2: |
+    gateways:
+    - xwiki-gateway
+    hosts:
+    - '*'
+    http:
+    - match:
+      - uri:
+          prefix: /
+      route:
+      - destination:
+          host: release-xwiki
+          port:
+            number: 80

--- a/tests/__snapshot__/ingress_test.yaml.snap
+++ b/tests/__snapshot__/ingress_test.yaml.snap
@@ -2,10 +2,25 @@ should set values properly:
   1: |
     kubernetes.io/ingress.class: nginx
   2: |
+    null
+  3: |
     rules:
     - http:
         paths:
         - backend:
-            serviceName: release-xwiki
-            servicePort: 80
+            service:
+              name: release-xwiki
+              port:
+                number: 80
           path: /
+          pathType: ImplementationSpecific
+  4: |
+    ports:
+    - name: tcp
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: release-xwiki
+    sessionAffinity: ClientIP
+    type: ClusterIP

--- a/tests/configmaps_test.yaml
+++ b/tests/configmaps_test.yaml
@@ -18,7 +18,7 @@ tests:
           value: release-xwiki
       - matchRegex:
           path: metadata.labels.chart
-          value: xwiki-*
+          pattern: xwiki-*
       - equal:
           path: metadata.labels.release
           value: release

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -11,17 +11,22 @@ tests:
     asserts:
       - isKind:
           of: Deployment
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image
           value: default:latest
+        documentIndex: 0
       - matchSnapshot:
           path: spec.template.spec.containers[0].env
+        documentIndex: 0
       - matchRegex:
           path: metadata.labels.app
           pattern: default-*
+        documentIndex: 0
       - matchRegex:
           path: metadata.labels.app
           pattern: -latest
+        documentIndex: 0
   - it: should use mysql lts image
     set:
       image.tag: latest
@@ -29,20 +34,25 @@ tests:
     asserts:
       - isKind:
           of: Deployment
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image
           value: xwiki:lts-mysql-tomcat
+        documentIndex: 0
       - matchSnapshot:
           path: spec.template.spec.containers[0].env
+        documentIndex: 0
       - matchRegex:
           path: metadata.labels.app
           pattern: xwiki-*
       - matchRegex:
           path: metadata.labels.app
           pattern: -lts-mysql-tomcat
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
           value: mysql-password
+        documentIndex: 0
   - it: should use postgres lts image
     set:
       image.tag: latest
@@ -50,20 +60,25 @@ tests:
     asserts:
       - isKind:
           of: Deployment
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image
           value: xwiki:lts-postgres-tomcat
+        documentIndex: 0
       - matchSnapshot:
           path: spec.template.spec.containers[0].env
+        documentIndex: 0
       - matchRegex:
           path: metadata.labels.app
           pattern: xwiki-*
       - matchRegex:
           path: metadata.labels.app
           pattern: -lts-postgresql-tomcat
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
           value: postgresql-password
+        documentIndex: 0
   - it: should use mysql lts image when mariadb is specified as it is compatible with mysql
     set:
       image.tag: latest
@@ -71,20 +86,25 @@ tests:
     asserts:
       - isKind:
           of: Deployment
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image
           value: xwiki:lts-mysql-tomcat
+        documentIndex: 0
       - matchSnapshot:
           path: spec.template.spec.containers[0].env
+        documentIndex: 0
       - matchRegex:
           path: metadata.labels.app
           pattern: xwiki-*
       - matchRegex:
           path: metadata.labels.app
           pattern: -lts-mariadb-tomcat
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
           value: mariadb-password
+        documentIndex: 0
   - it: should properly set value
     set:
       image.pullPolicy: IfNotPresent
@@ -94,34 +114,45 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-xwiki
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8080
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name
           value: xwiki-data
+        documentIndex: 0
       - equal:
           path: spec.template.spec.volumes[0].name
           value: xwiki-solr-data
+        documentIndex: 0
       - equal:
           path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
           value: xwiki-solr
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].name
           value: xwiki-solr-data
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[2].name
           value: xwiki-tomcat-conf
+        documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[2].mountPath
           value: /usr/local/tomcat/conf/web.xml
+        documentIndex: 0
       - matchSnapshot:
           path: spec.template.spec.containers[0].volumeMounts
+        documentIndex: 0
       - matchSnapshot:
           path: spec.template.spec.volumes
+        documentIndex: 0
   - it: should properly set value for xwiki pvc
     set:
       mysql.enabled: true
@@ -151,4 +182,3 @@ tests:
           path: metadata.name
           value: xwiki-solr
         documentIndex: 2
-

--- a/tests/gateway_test.yaml
+++ b/tests/gateway_test.yaml
@@ -10,11 +10,13 @@ tests:
     asserts:
       - isKind:
           of: Gateway
+        documentIndex: 0
       - isAPIVersion:
           of: networking.istio.io/v1alpha3
       - equal:
           path: metadata.name
           value: xwiki-gateway
+        documentIndex: 0
       - matchSnapshot:
           path: spec
   - it: should properly set value of VirtualService

--- a/tests/ingress_test.yaml
+++ b/tests/ingress_test.yaml
@@ -16,6 +16,7 @@ tests:
     asserts:
       - isKind:
           of: Ingress
+        template: ingress.yaml
       - matchSnapshot:
           path: metadata.annotations
       - equal:

--- a/tests/secrets_test.yaml
+++ b/tests/secrets_test.yaml
@@ -1,4 +1,4 @@
-suite: test configmaps
+suite: test secrets
 templates:
   - secrets.yaml
 tests:
@@ -18,7 +18,7 @@ tests:
           value: release-xwiki
       - matchRegex:
           path: metadata.labels.chart
-          value: xwiki-*
+          pattern: xwiki-*
       - equal:
           path: metadata.labels.release
           value: release

--- a/tests/service_test.yaml
+++ b/tests/service_test.yaml
@@ -4,6 +4,7 @@ templates:
   - deployment.yaml
 tests:
   - it: should set values properly
+    template: service.yaml
     set:
       mysql.enabled: true
     set:
@@ -32,11 +33,14 @@ tests:
       - equal:
           path: spec.selector.app
           value: release-xwiki
+        template: service.yaml
       - equal:
           path: spec.selector.matchLabels.app
           value: release-xwiki
         template: deployment.yaml
+        documentIndex: 0
       - equal:
           path: spec.template.metadata.labels.app
           value: release-xwiki
         template: deployment.yaml
+        documentIndex: 0

--- a/tests/tomcat-configmap_test.yaml
+++ b/tests/tomcat-configmap_test.yaml
@@ -18,7 +18,7 @@ tests:
           value: release-xwiki
       - matchRegex:
           path: metadata.labels.chart
-          value: xwiki-*
+          pattern: xwiki-*
       - equal:
           path: metadata.labels.release
           value: release

--- a/tests/xwiki-cfg-configmap_test.yaml
+++ b/tests/xwiki-cfg-configmap_test.yaml
@@ -18,7 +18,7 @@ tests:
           value: release-xwiki
       - matchRegex:
           path: metadata.labels.chart
-          value: xwiki-*
+          pattern: xwiki-*
       - equal:
           path: metadata.labels.release
           value: release

--- a/tests/xwiki-properties-configmap_test.yaml
+++ b/tests/xwiki-properties-configmap_test.yaml
@@ -18,7 +18,7 @@ tests:
           value: release-xwiki
       - matchRegex:
           path: metadata.labels.chart
-          value: xwiki-*
+          pattern: xwiki-*
       - equal:
           path: metadata.labels.release
           value: release


### PR DESCRIPTION
The chart's unit tests are currently broken. This PR both fixes the broken tests and updates them to work with the currently active fork of helm-unittest, [quintush's](https://github.com/quintush/helm-unittest).

On top of that, a CI workflow was added to run the unit tests whenever pull requests are created or merged into `master`.
